### PR TITLE
upgraded to 1.20.5 go and added release configuration

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -7,13 +7,28 @@ etcd-wrapper:
         preprocess:
           'inject-commit-hash'
         inject_effective_version: true
+      publish:
+        oci-builder: 'docker-buildx'
+        platforms:
+        - linux/amd64
+        - linux/arm64
+        dockerimages:
+          etcd-wrapper:
+            registry: 'gcr-readwrite'
+            image: 'eu.gcr.io/gardener-project/gardener/etcd-wrapper'
+            dockerfile: 'Dockerfile'
+            inputs:
+              repos:
+                source: ~
+              steps:
+                build: ~
     steps:
       check:
-        image: 'golang:1.20.1'
+        image: 'golang:1.20.5'
       test:
-        image: 'golang:1.20.1'
+        image: 'golang:1.20.5'
       build:
-        image: 'golang:1.20.1'
+        image: 'golang:1.20.5'
         output_dir: 'binary'
 
   jobs:
@@ -24,3 +39,16 @@ etcd-wrapper:
     pull-request:
       traits:
         pull-request: ~
+    release:
+      traits:
+        version:
+          preprocess: 'finalize'
+        release:
+          nextversion: 'bump_minor'
+        slack:
+          default_channel: 'internal_scp_workspace'
+          channel_cfgs:
+            internal_scp_workspace:
+              channel_name: 'C0177NLL8V9' # gardener-etcd
+              slack_cfg_name: 'scp_workspace'
+        component_descriptor: ~


### PR DESCRIPTION
**What this PR does / why we need it**:

- [x] Adds release job configuration to CI pipeline_definition.
- [x] Upgrades golang version to 1.20.5

**Which issue(s) this PR fixes**:
Fixes #5 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Release job added in CI pipeline_definition and golang version upgraded to 1.20.5
```
