### PR TITLE
Add CVE categorization for etcd-wrapper

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -22,6 +22,15 @@ etcd-wrapper:
                 source: ~
               steps:
                 build: ~
+            resource_labels:
+            - name: 'gardener.cloud/cve-categorisation'
+              value:
+                network_exposure: 'private' # TODO: change to 'protected' once DB initialization moves to etcd-wrapper, since it might need to contact snapstore provider for sanity checks
+                authentication_enforced: true
+                user_interaction: 'gardener-operator'
+                confidentiality_requirement: 'high'
+                integrity_requirement: 'high'
+                availability_requirement: 'high'
     steps:
       check:
         image: 'golang:1.20.5'


### PR DESCRIPTION
**What this PR does / why we need it**:
Add CVE categorization to etcd-wrapper within the gardener context.

**Which issue(s) this PR fixes**:
Fixes partially https://github.com/gardener/etcd-druid/issues/633

**Special notes for your reviewer**:
/invite @ashwani2k 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Add CVE categorization for etcd-wrapper.
```
