### PR TITLE
Set umask to `0077` for `etcd` process

### DIFF
--- a/cmd/etcd.go
+++ b/cmd/etcd.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"context"
 	"flag"
+	"syscall"
 	"time"
 
 	"github.com/gardener/etcd-wrapper/internal/types"
@@ -76,5 +77,7 @@ func InitAndStartEtcd(ctx context.Context, cancelFn context.CancelFunc, logger *
 	if err := etcdApp.Setup(); err != nil {
 		return err
 	}
+
+	syscall.Umask(0077)
 	return etcdApp.Start()
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
Set umask to `0077` for `etcd` process. This PR is similar to the one for `etcd-custom-image` [ref](https://github.com/gardener/etcd-custom-image/pull/34).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `etcd` process now runs with umask set to `0077`, this way the files it creates have no permissions on `group` and `others` level.
```
