### PR TITLE
switch GCR -> Artifact-Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,12 +1,11 @@
 etcd-wrapper:
-  template: 'default'
   base_definition:
-    repo: ~
     traits:
       version:
         preprocess:
           'inject-commit-hash'
         inject_effective_version: true
+      component_descriptor: ~
       publish:
         oci-builder: 'docker-buildx'
         platforms:
@@ -14,7 +13,6 @@ etcd-wrapper:
         - linux/arm64
         dockerimages:
           etcd-wrapper:
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/etcd-wrapper'
             dockerfile: 'Dockerfile'
             inputs:
@@ -44,7 +42,6 @@ etcd-wrapper:
     head-update:
       traits:
         draft_release: ~
-        component_descriptor: ~
     pull-request:
       traits:
         pull-request: ~
@@ -60,4 +57,3 @@ etcd-wrapper:
             internal_scp_workspace:
               channel_name: 'C0177NLL8V9' # gardener-etcd
               slack_cfg_name: 'scp_workspace'
-        component_descriptor: ~

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -5,7 +5,8 @@ etcd-wrapper:
         preprocess:
           'inject-commit-hash'
         inject_effective_version: true
-      component_descriptor: ~
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
       publish:
         oci-builder: 'docker-buildx'
         platforms:
@@ -13,7 +14,7 @@ etcd-wrapper:
         - linux/arm64
         dockerimages:
           etcd-wrapper:
-            image: 'eu.gcr.io/gardener-project/gardener/etcd-wrapper'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/etcd-wrapper
             dockerfile: 'Dockerfile'
             inputs:
               repos:
@@ -42,6 +43,9 @@ etcd-wrapper:
     head-update:
       traits:
         draft_release: ~
+        component_descriptor:
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
     pull-request:
       traits:
         pull-request: ~
@@ -49,6 +53,12 @@ etcd-wrapper:
       traits:
         version:
           preprocess: 'finalize'
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
+        publish:
+          dockerimages:
+            etcd-wrapper:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/etcd-wrapper
         release:
           nextversion: 'bump_minor'
         slack:


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
