### PR TITLE
[hotfix-v0.1] Switch GCR -> Artifact-Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,12 +1,11 @@
 etcd-wrapper:
-  template: 'default'
   base_definition:
-    repo: ~
     traits:
       version:
         preprocess:
           'inject-commit-hash'
         inject_effective_version: true
+      component_descriptor: ~
       publish:
         oci-builder: 'docker-buildx'
         platforms:
@@ -14,7 +13,6 @@ etcd-wrapper:
         - linux/arm64
         dockerimages:
           etcd-wrapper:
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/etcd-wrapper'
             dockerfile: 'Dockerfile'
             inputs:
@@ -44,7 +42,6 @@ etcd-wrapper:
     head-update:
       traits:
         draft_release: ~
-        component_descriptor: ~
     pull-request:
       traits:
         pull-request: ~
@@ -60,4 +57,3 @@ etcd-wrapper:
             internal_scp_workspace:
               channel_name: 'C0177NLL8V9' # gardener-etcd
               slack_cfg_name: 'scp_workspace'
-        component_descriptor: ~

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -5,7 +5,8 @@ etcd-wrapper:
         preprocess:
           'inject-commit-hash'
         inject_effective_version: true
-      component_descriptor: ~
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
       publish:
         oci-builder: 'docker-buildx'
         platforms:
@@ -13,7 +14,7 @@ etcd-wrapper:
         - linux/arm64
         dockerimages:
           etcd-wrapper:
-            image: 'eu.gcr.io/gardener-project/gardener/etcd-wrapper'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/etcd-wrapper
             dockerfile: 'Dockerfile'
             inputs:
               repos:
@@ -42,6 +43,9 @@ etcd-wrapper:
     head-update:
       traits:
         draft_release: ~
+        component_descriptor:
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
     pull-request:
       traits:
         pull-request: ~
@@ -49,6 +53,12 @@ etcd-wrapper:
       traits:
         version:
           preprocess: 'finalize'
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
+        publish:
+          dockerimages:
+            etcd-wrapper:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/etcd-wrapper
         release:
           nextversion: 'bump_minor'
         slack:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

**What this PR does / why we need it**:
Cherry-pick of #19

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.
```
