### PR TITLE
[hotfix-v0.1]Closing the ReadinessProbe discussion with GET call using --consistency=linearizable. (#13)

### DIFF
--- a/docs/concepts/bootstrap.md
+++ b/docs/concepts/bootstrap.md
@@ -48,7 +48,7 @@ Initiliasation loop exits only when the status returned from `etcd-backup-sideca
 
 Start phase mainly comprises of two steps:
 
-1. Set up a readiness probe at `/readyz` where anyone can query to verify if the etcd application is running.
+1. Set up a readiness probe at `/readyz` where anyone can query to verify if the etcd application(single node cluster or multi-node cluster) is ready to accept client traffic.
 
 2. Start an embedded etcd using the fetched etcd configuration.
 

--- a/internal/app/readycheck.go
+++ b/internal/app/readycheck.go
@@ -85,7 +85,7 @@ func (a *Application) queryAndUpdateEtcdReadiness() {
 func (a *Application) isEtcdReady() bool {
 	etcdConnCtx, cancelFunc := context.WithTimeout(a.ctx, etcdGetTimeout)
 	defer cancelFunc()
-	_, err := a.etcdClient.Get(etcdConnCtx, "foo" /*, clientv3.WithSerializable()*/)
+	_, err := a.etcdClient.Get(etcdConnCtx, "foo")
 	if err != nil {
 		a.logger.Error("failed to retrieve from etcd db", zap.Error(err))
 	}


### PR DESCRIPTION

**What this PR does / why we need it**:
CherryPick: https://github.com/gardener/etcd-wrapper/pull/13

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
