### PR TITLE
Minor change in generating license headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ include hack/tools.mk
 
 .PHONY: add-license-headers
 add-license-headers: $(GO_ADD_LICENSE)
-	@./hack/add_license_headers.sh ${YEAR}
+	@./hack/add_license_headers.sh
 
 .PHONY: build
 build:

--- a/hack/add_license_headers.sh
+++ b/hack/add_license_headers.sh
@@ -7,18 +7,11 @@ set -e
 
 echo "> Adding Apache License header to all go files where it is not present"
 
-YEAR=$1
-if [[ -z "$1" ]]; then
-  cat << EOF
-Unspecified 'YEAR' argument.
-Usage: add_licence_headers.sh <YEAR>
-EOF
-  exit 1
-fi
+YEAR="$(date +%Y)"
 
 temp_file=$(mktemp)
 trap "rm -f $temp_file" EXIT
-sed "s/{YEAR}/${YEAR}/g" hack/license_boilerplate.txt > $temp_file
+sed "s/YEAR/${YEAR}/g" hack/license_boilerplate.txt > $temp_file
 
 # Uses the tool https://github.com/google/addlicense
 addlicense \

--- a/hack/license_boilerplate.txt
+++ b/hack/license_boilerplate.txt
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: {YEAR} SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: YEAR SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Remove the need for passing `YEAR` env var to `make add-license-headers` target. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @unmarshall 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
