### PR TITLE
Update golang images to 1.23.4; add OCM responsibles

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -9,8 +9,7 @@ etcd-wrapper:
               we use gosec for sast scanning. See attached log.
     traits:
       version:
-        preprocess:
-          'inject-commit-hash'
+        preprocess: 'inject-commit-hash'
         inject_effective_version: true
       component_descriptor:
         ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
@@ -37,13 +36,17 @@ etcd-wrapper:
                 confidentiality_requirement: 'high'
                 integrity_requirement: 'high'
                 availability_requirement: 'high'
+            - name: 'cloud.gardener.cnudie/responsibles'
+              value:
+                - type: 'githubTeam'
+                  teamname: 'gardener/etcd-druid-maintainers'
     steps:
       check:
-        image: 'golang:1.23.1'
+        image: 'golang:1.23.4'
       test:
-        image: 'golang:1.23.1'
+        image: 'golang:1.23.4'
       build:
-        image: 'golang:1.23.1'
+        image: 'golang:1.23.4'
         output_dir: 'binary'
 
   jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.1 as builder
+FROM golang:1.23.4 as builder
 WORKDIR /go/src/github.com/gardener/etcd-wrapper
 COPY . .
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/etcd-wrapper
 
-go 1.23.1
+go 1.23.0
 
 // These are test-only dependencies
 require github.com/onsi/gomega v1.34.2


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area performance
/kind task

**What this PR does / why we need it**:
- [x] Update golang images to 1.23.4
- [x] Update golang version in go.mod to 1.23.0, in line with https://github.com/gardener/etcd-druid/pull/925
- [x] Add OCM responsibles

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Update golang images to v1.23.4.
```
