### PR TITLE
Add code to remove legacy `validation_marker` file that created by etcd-custom-image on the filesystem

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -93,7 +93,7 @@ func (a *Application) Start() error {
 	if err = a.startEtcd(); err != nil {
 		return err
 	}
-	// Delete validation marker after etcd starts successfully
+	// Delete exit code file after etcd starts successfully
 	if err = bootstrap.CleanupExitCode(types.DefaultExitCodeFilePath); err != nil {
 		a.logger.Warn("failed to clean-up last captured exit code", zap.Error(err))
 	}

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -115,6 +115,14 @@ func (i *initializer) tryGetEtcdConfig(ctx context.Context, maxRetries int, inte
 
 func determineValidationMode(exitCodeFilePath string, logger *zap.Logger) brclient.ValidationType {
 	var err error
+
+	// remove legacy validation_marker file created by etcd-custom-image
+	if _, err = os.Stat(types.ValidationMarkerFilePath); err == nil {
+		if err = os.Remove(types.ValidationMarkerFilePath); err != nil {
+			logger.Error("error in removing validation_marker file", zap.String("validationMarkerFilePath", types.ValidationMarkerFilePath), zap.Error(err))
+		}
+	}
+
 	if _, err = os.Stat(exitCodeFilePath); err == nil {
 		data, err := os.ReadFile(exitCodeFilePath) // #nosec G304 -- only path passed is `DefaultExitCodeFilePath`, no user input is used.
 		if err != nil {

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -117,10 +117,8 @@ func determineValidationMode(exitCodeFilePath string, logger *zap.Logger) brclie
 	var err error
 
 	// remove legacy validation_marker file created by etcd-custom-image
-	if _, err = os.Stat(types.ValidationMarkerFilePath); err == nil {
-		if err = os.Remove(types.ValidationMarkerFilePath); err != nil {
-			logger.Error("error in removing validation_marker file", zap.String("validationMarkerFilePath", types.ValidationMarkerFilePath), zap.Error(err))
-		}
+	if err = CleanupExitCode(types.ValidationMarkerFilePath); err != nil {
+		logger.Error("error in removing validation_marker file", zap.String("validationMarkerFilePath", types.ValidationMarkerFilePath), zap.Error(err))
 	}
 
 	if _, err = os.Stat(exitCodeFilePath); err == nil {

--- a/internal/types/constants.go
+++ b/internal/types/constants.go
@@ -13,6 +13,8 @@ const (
 	DefaultBackupRestoreHostPort = ":8080"
 	// DefaultExitCodeFilePath defines the default file path for the file that stores the exit code of the previous run
 	DefaultExitCodeFilePath = "/var/etcd/data/exit_code"
+	// ValidationMarkerFilePath defines the file path to the legacy file that was used to record exit code of the previous run
+	ValidationMarkerFilePath = "/var/etcd/data/validation_marker"
 	// DefaultLogLevel defines the default log level for any zap loggers created
 	DefaultLogLevel = zapcore.InfoLevel
 )


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area compliance security
/kind task

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #37

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
