### PR TITLE
Tag docker images built via pipeline release process as `latest`

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -69,6 +69,7 @@ etcd-wrapper:
           dockerimages:
             etcd-wrapper:
               image: europe-docker.pkg.dev/gardener-project/releases/gardener/etcd-wrapper
+              tag_as_latest: True
         release:
           nextversion: 'bump_minor'
           assets:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Tag docker images built via pipeline release process as `latest`, to allow users to use the latest version of etcd-wrapper as `europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper:latest`, without needing to specify the latest released version of the component.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @renormalize @anveshreddy18 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Tag docker images built via pipeline release process as `latest`.
```
