### PR TITLE
Fix etcd data directory file permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@
 #########################################
 
 BIN_DIR := bin
+VERSION             := $(shell cat VERSION)
+IMAGE_PATH          := europe-docker.pkg.dev/gardener-project/snapshots/gardener/etcd-wrapper
+IMG                 := $(IMAGE_PATH):$(VERSION)
+PLATFORM            ?= $(shell docker info --format '{{.OSType}}/{{.Architecture}}')
 
 include hack/tools.mk
 
@@ -13,6 +17,14 @@ add-license-headers: $(GO_ADD_LICENSE)
 .PHONY: build
 build:
 	@./hack/build.sh
+
+.PHONY: docker-build
+docker-build:
+	@docker buildx build --platform=$(PLATFORM) -t $(IMG) -f Dockerfile --rm .
+
+.PHONY: docker-push
+docker-push:
+	@docker push $(IMG)
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,10 @@
 
 BIN_DIR := bin
 VERSION             := $(shell cat VERSION)
-IMAGE_PATH          := europe-docker.pkg.dev/gardener-project/snapshots/gardener/etcd-wrapper
-IMG                 := $(IMAGE_PATH):$(VERSION)
+IMAGE_REGISTRY      := europe-docker.pkg.dev/gardener-project/snapshots
+IMAGE_REPOSITORY    := $(IMAGE_REGISTRY)/gardener/etcd-wrapper
+IMAGE_TAG           := $(VERSION)
+IMAGE               := $(IMAGE_REPOSITORY):$(IMAGE_TAG)
 PLATFORM            ?= $(shell docker info --format '{{.OSType}}/{{.Architecture}}')
 
 include hack/tools.mk
@@ -20,11 +22,12 @@ build:
 
 .PHONY: docker-build
 docker-build:
-	@docker buildx build --platform=$(PLATFORM) -t $(IMG) -f Dockerfile --rm .
+	@docker buildx build --platform=$(PLATFORM) -t $(IMAGE) -f Dockerfile --rm .
 
 .PHONY: docker-push
 docker-push:
-	@docker push $(IMG)
+	@if ! docker images $(IMAGE_REPOSITORY) | awk '{ print $$2 }' | grep -q -F $(IMAGE_TAG); then echo "$(IMAGE_REPOSITORY) version $(IMAGE_TAG) is not yet built. Please run 'make docker-build'"; false; fi
+	@docker push $(IMAGE)
 
 .PHONY: clean
 clean:

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -6,6 +6,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"syscall"
 	"time"
@@ -88,6 +89,12 @@ func (a *Application) Start() error {
 			)
 		}
 	}()
+
+	// Change file permissions for files previously created without umask 0077
+	// TODO (shreyas-s-rao): remove this temporary code in etcd-wrapper v0.8.0
+	if err = bootstrap.ChangeFilePermissions(a.cfg.Dir, 0640); err != nil {
+		return fmt.Errorf("failed to change file permissions: %w", err)
+	}
 
 	// Create embedded etcd and start.
 	if err = a.startEtcd(); err != nil {

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -80,6 +81,19 @@ func (i *initializer) Run(ctx context.Context) (*embed.Config, error) {
 	}
 	i.logger.Info("Etcd initialization succeeded")
 	return i.tryGetEtcdConfig(ctx, defaultBackupRestoreMaxRetries, defaultBackOffBetweenRetries)
+}
+
+// ChangeFilePermissions changes the file permissions of all files in the given directory and its subdirectories recursively.
+func ChangeFilePermissions(dir string, mode os.FileMode) error {
+	return filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		return os.Chmod(path, mode)
+	})
 }
 
 // CaptureExitCode captures the exit signal into a file `exit_code`


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area security compliance
/kind task

**What this PR does / why we need it**:
Change permissions for files in etcd data directory, to address issue of files previously created with wider permissions when umask was not yet set to `0077`. Files will now be chmod-ed to 0640, as per [DISA STIG](https://www.stigviewer.com/stig/kubernetes/) standards. This is temporary code, and will be removed in etcd-wrapper:v0.8.0.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Change permissions for files in etcd data directory to `0640`.
```
```feature developer
Introduce make targets `docker-build` and `docker-push` to build and push etcd-wrapper docker images to the configured registry.
```
