### PR TITLE
Check for non-existent etcd data directory when trying to fix permissions for its files

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -69,6 +69,12 @@ func (a *Application) Setup() error {
 func (a *Application) Start() error {
 	var err error
 
+	// Change file permissions for files previously created without umask 0077
+	// TODO (shreyas-s-rao): remove this temporary code in etcd-wrapper v0.8.0
+	if err = bootstrap.ChangeFilePermissions(a.cfg.Dir, 0640); err != nil {
+		return fmt.Errorf("failed to change file permissions: %w", err)
+	}
+
 	// Create etcd client for readiness probe
 	cli, err := a.createEtcdClient()
 	if err != nil {
@@ -89,12 +95,6 @@ func (a *Application) Start() error {
 			)
 		}
 	}()
-
-	// Change file permissions for files previously created without umask 0077
-	// TODO (shreyas-s-rao): remove this temporary code in etcd-wrapper v0.8.0
-	if err = bootstrap.ChangeFilePermissions(a.cfg.Dir, 0640); err != nil {
-		return fmt.Errorf("failed to change file permissions: %w", err)
-	}
 
 	// Create embedded etcd and start.
 	if err = a.startEtcd(); err != nil {

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -91,7 +91,7 @@ func ChangeFilePermissions(dir string, mode os.FileMode) error {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
-		return fmt.Errorf("error stating directory %s: %v", dir, err)
+		return fmt.Errorf("error stating directory %s: %w", dir, err)
 	}
 
 	if !info.IsDir() {
@@ -100,13 +100,13 @@ func ChangeFilePermissions(dir string, mode os.FileMode) error {
 
 	return filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
-			return fmt.Errorf("error walking the path %q: %v", path, err)
+			return fmt.Errorf("error walking the path %q: %w", path, err)
 		}
 		if d.IsDir() {
 			return nil
 		}
 		if err = os.Chmod(path, mode); err != nil {
-			return fmt.Errorf("error changing file permissions for %q: %v", path, err)
+			return fmt.Errorf("error changing file permissions for %q: %w", path, err)
 		}
 		return nil
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane security
/kind bug

**What this PR does / why we need it**:
Check for non-existent etcd data directory when trying to fix permissions for files in it. This fixes a regression caused by #51 .

**Which issue(s) this PR fixes**:
Fixes #53 

**Special notes for your reviewer**:
/invite @anveshreddy18 @seshachalam-yv 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
