### PR TITLE
Change permissions of files in etcd data directory to `0600` (#55)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -71,7 +71,7 @@ func (a *Application) Start() error {
 
 	// Change file permissions for files previously created without umask 0077
 	// TODO (shreyas-s-rao): remove this temporary code in etcd-wrapper v0.8.0
-	if err = bootstrap.ChangeFilePermissions(a.cfg.Dir, 0640); err != nil {
+	if err = bootstrap.ChangeFilePermissions(a.cfg.Dir, 0600); err != nil {
 		return fmt.Errorf("failed to change file permissions: %w", err)
 	}
 

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -57,7 +57,7 @@ func TestChangeFilePermissions(t *testing.T) {
 				}
 				return testDir
 			},
-			mode:        0640,
+			mode:        0600,
 			expectError: false,
 			verify: func(t *testing.T, testDir string, mode os.FileMode) {
 				g := NewWithT(t)
@@ -77,7 +77,7 @@ func TestChangeFilePermissions(t *testing.T) {
 			setup: func(testDir string) string {
 				return filepath.Join(testDir, "nonexistent/path")
 			},
-			mode:        0640,
+			mode:        0600,
 			expectError: false,
 			verify:      func(_ *testing.T, _ string, _ os.FileMode) {},
 		},
@@ -91,7 +91,7 @@ func TestChangeFilePermissions(t *testing.T) {
 				}
 				return filePath
 			},
-			mode:        0640,
+			mode:        0600,
 			expectError: true,
 			verify:      func(_ *testing.T, _ string, _ os.FileMode) {},
 		},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area compliance security
/kind enhancement task

**What this PR does / why we need it**:
Cherry-pick of #55 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Change permissions of files in etcd data directory to `0600`.
```
