### PR TITLE
[hotfix-v0.5] Update golang images to `1.24.4`

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -42,11 +42,11 @@ etcd-wrapper:
                   teamname: 'gardener/etcd-druid-maintainers'
     steps:
       check:
-        image: 'golang:1.24.2'
+        image: 'golang:1.24.4'
       test:
-        image: 'golang:1.24.2'
+        image: 'golang:1.24.4'
       build:
-        image: 'golang:1.24.2'
+        image: 'golang:1.24.4'
         output_dir: 'binary'
 
   jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.2 as builder
+FROM golang:1.24.4 as builder
 WORKDIR /go/src/github.com/gardener/etcd-wrapper
 COPY . .
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
Update golang images to `1.24.4`. Cherry-pick of #57 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @Shreyas-s14 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Update golang images to `1.24.4`.
```
