### PR TITLE
Updated docs to fix broken links.

### DIFF
--- a/docs/concepts/bootstrap.md
+++ b/docs/concepts/bootstrap.md
@@ -36,7 +36,7 @@ If initialisation status is `New` then it does the following:
 
 * It sleeps for some time to prevent a busy loop and goes back to Step-1.
 
-> For more details about the validation modes check [here](https://github.com/gardener/etcd-backup-restore/blob/master/doc/proposals/validation.md).
+> For more details about the validation modes check [here](https://github.com/gardener/etcd-backup-restore/blob/master/docs/proposals/validation.md).
 
 If initiliasation is either `Progress` or `Failed` it will sleep for some time to prevent busy loop and then goes back to Step-1 
 

--- a/docs/development/local-setup.md
+++ b/docs/development/local-setup.md
@@ -1,6 +1,6 @@
 # Local KIND Cluster based ETCD Cluster Setup
 
-To make development and testing of `etcd-wrapper` easier we also provide [scripts](../hack/local-dev) which will help you generate and deploy all required resources to a locally started [KIND](https://kind.sigs.k8s.io/) cluster.
+To make development and testing of `etcd-wrapper` easier we also provide [scripts](../../hack/local-dev) which will help you generate and deploy all required resources to a locally started [KIND](https://kind.sigs.k8s.io/) cluster.
 
 ## Setup KIND cluster
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area documentation
/kind bug

**What this PR does / why we need it**:
Some of the links in the docs sections were outdated. This PR fixes them by updating them with the new links.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**: 
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->

```other operator
updated links in docs.
```
