### PR TITLE
Add GHA workflow `PR Review Timeline`

### DIFF
--- a/.github/workflows/pr-review-timeline.yaml
+++ b/.github/workflows/pr-review-timeline.yaml
@@ -1,0 +1,26 @@
+name: PR Review Timeline
+
+on:
+  pull_request:
+    types: [opened, closed, reopened, ready_for_review, review_requested, assigned, synchronize]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+
+jobs:
+  pr-review-timeline:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: PR Review Timeline
+        uses: shreyas-s-rao/pr-review-timeline@v0.2.1
+        id: timeline
+      - name: Output Timeline JSON
+        run: |
+          echo "${{ steps.timeline.outputs.timeline-json }}" > pr_review_timeline.json
+      - name: Upload Timeline Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-review-timeline
+          path: pr_review_timeline.json


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

Introduce new GHA workflow `PR Review Timeline`, which uses https://github.com/marketplace/actions/pr-review-timeline to publish the review timeline for a PR in the Checks tab. This makes it easier to track PR timelines, especially useful for large or long-running PRs with multiple review cycles.

**Checklist**:
NA

**Special notes for your reviewer**:

This is what the output will look like:
<img width="1689" height="1015" alt="Screenshot 2026-02-06 at 11 14 09 AM" src="https://github.com/user-attachments/assets/6092899f-645a-4196-bbe1-ee130ae295c0" />

Current summary for this action is already available for this PR here: https://github.com/gardener/etcd-wrapper/actions/runs/21740476540?pr=79

Please note, this will only be available in the action execution page and not the PR description itself, since the action input `publish-to-pr` is set to `false` by default.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Add GHA workflow `PR Review Timeline` for easy tracking of reviewer timelines for PRs.
```
