### PR TITLE
Apply peer `skip-client-san-verification` from etcd config (#1331)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	go.etcd.io/etcd/client/v3 v3.5.27
 	go.etcd.io/etcd/server/v3 v3.5.27
 	go.uber.org/zap v1.27.1
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -75,5 +76,4 @@ require (
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -151,10 +151,8 @@ func (i *initializer) tryGetEtcdConfig(ctx context.Context, maxRetries int, inte
 	return cfg, nil
 }
 
-// etcdConfigWithPeerSkipSAN parses only the nested
-// peer-transport-security.skip-client-san-verification key from the etcd config
-// YAML written by etcd-druid. The key path matches etcd v3.6's native
-// securityConfig YAML layout.
+// etcdConfigWithPeerSkipSAN parses only the nested "peer-transport-security.skip-client-san-verification"
+// key present in the etcd config-map template passed by etcd-druid.
 type etcdConfigWithPeerSkipSAN struct {
 	PeerTransportSecurity struct {
 		SkipClientSANVerification bool `json:"skip-client-san-verification"`
@@ -165,6 +163,11 @@ type etcdConfigWithPeerSkipSAN struct {
 // sets cfg.PeerTLSInfo.SkipClientSANVerify to the value of the nested
 // peer-transport-security.skip-client-san-verification key. An absent key is
 // treated as false.
+//
+// TODO(@seshachalam-yv): remove this handling once the project moves to etcd
+// v3.6.x — etcd v3.6 honors peer-transport-security.skip-client-san-verification
+// natively in its config file, so embed.ConfigFromFile will populate
+// cfg.PeerTLSInfo.SkipClientSANVerify and this shim is no longer needed.
 func applyPeerSkipClientSANVerify(configFilePath string, cfg *embed.Config, logger *zap.Logger) error {
 	data, err := os.ReadFile(configFilePath) // #nosec G304 -- configFilePath is from trusted backup-restore service
 	if err != nil {
@@ -172,10 +175,12 @@ func applyPeerSkipClientSANVerify(configFilePath string, cfg *embed.Config, logg
 	}
 	parsed := etcdConfigWithPeerSkipSAN{}
 	if err := sigsyaml.Unmarshal(data, &parsed); err != nil {
-		return fmt.Errorf("failed to unmarshal etcd config for peer-transport-security.skip-client-san-verification: %w", err)
+		return fmt.Errorf("failed to parse etcd config: %w", err)
 	}
 	cfg.PeerTLSInfo.SkipClientSANVerify = parsed.PeerTransportSecurity.SkipClientSANVerification
-	logger.Info("Applied peer skip-client-san-verification on PeerTLSInfo", zap.Bool("skipClientSANVerify", cfg.PeerTLSInfo.SkipClientSANVerify))
+	if cfg.PeerTLSInfo.SkipClientSANVerify {
+		logger.Info("Set PeerTLSInfo.SkipClientSANVerify=true from peer-transport-security.skip-client-san-verification")
+	}
 	return nil
 }
 

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -20,6 +20,7 @@ import (
 
 	"go.etcd.io/etcd/server/v3/embed"
 	"go.uber.org/zap"
+	sigsyaml "sigs.k8s.io/yaml"
 )
 
 const (
@@ -140,7 +141,42 @@ func (i *initializer) tryGetEtcdConfig(ctx context.Context, maxRetries int, inte
 	}
 	etcdConfigFilePath := opResult.Value
 	i.logger.Info("Fetched and written etcd configuration", zap.String("path", etcdConfigFilePath))
-	return embed.ConfigFromFile(etcdConfigFilePath)
+	cfg, err := embed.ConfigFromFile(etcdConfigFilePath)
+	if err != nil {
+		return nil, err
+	}
+	if err := applyPeerSkipClientSANVerify(etcdConfigFilePath, cfg, i.logger); err != nil {
+		return nil, fmt.Errorf("failed to apply peer-transport-security.skip-client-san-verification: %w", err)
+	}
+	return cfg, nil
+}
+
+// etcdConfigWithPeerSkipSAN parses only the nested
+// peer-transport-security.skip-client-san-verification key from the etcd config
+// YAML written by etcd-druid. The key path matches etcd v3.6's native
+// securityConfig YAML layout.
+type etcdConfigWithPeerSkipSAN struct {
+	PeerTransportSecurity struct {
+		SkipClientSANVerification bool `json:"skip-client-san-verification"`
+	} `json:"peer-transport-security"`
+}
+
+// applyPeerSkipClientSANVerify reads the etcd config file at configFilePath and
+// sets cfg.PeerTLSInfo.SkipClientSANVerify to the value of the nested
+// peer-transport-security.skip-client-san-verification key. An absent key is
+// treated as false.
+func applyPeerSkipClientSANVerify(configFilePath string, cfg *embed.Config, logger *zap.Logger) error {
+	data, err := os.ReadFile(configFilePath) // #nosec G304 -- configFilePath is from trusted backup-restore service
+	if err != nil {
+		return fmt.Errorf("failed to read etcd config file: %w", err)
+	}
+	parsed := etcdConfigWithPeerSkipSAN{}
+	if err := sigsyaml.Unmarshal(data, &parsed); err != nil {
+		return fmt.Errorf("failed to unmarshal etcd config for peer-transport-security.skip-client-san-verification: %w", err)
+	}
+	cfg.PeerTLSInfo.SkipClientSANVerify = parsed.PeerTransportSecurity.SkipClientSANVerification
+	logger.Info("Applied peer skip-client-san-verification on PeerTLSInfo", zap.Bool("skipClientSANVerify", cfg.PeerTLSInfo.SkipClientSANVerify))
+	return nil
 }
 
 func determineValidationMode(exitCodeFilePath string, logger *zap.Logger) brclient.ValidationType {

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/gardener/etcd-wrapper/internal/types"
+	"go.etcd.io/etcd/server/v3/embed"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
@@ -331,4 +332,130 @@ func createSidecarConfig(tlsEnabled bool, hostPort string, caCertBundlePath stri
 		TLSEnabled:       tlsEnabled,
 		CaCertBundlePath: caCertBundlePath,
 	}
+}
+
+func TestApplyPeerSkipClientSANVerify(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	table := []struct {
+		description         string
+		configYAML          string
+		expectSkipSANVerify bool
+	}{
+		{
+			description:         "flag true: SkipClientSANVerify becomes true",
+			configYAML:          "name: test\npeer-transport-security:\n  skip-client-san-verification: true\n",
+			expectSkipSANVerify: true,
+		},
+		{
+			description:         "flag false: SkipClientSANVerify stays false",
+			configYAML:          "name: test\npeer-transport-security:\n  skip-client-san-verification: false\n",
+			expectSkipSANVerify: false,
+		},
+		{
+			description:         "flag absent under peer-transport-security: SkipClientSANVerify stays false",
+			configYAML:          "name: test\npeer-transport-security:\n  cert-file: /etc/foo.crt\n",
+			expectSkipSANVerify: false,
+		},
+		{
+			description:         "peer-transport-security absent: SkipClientSANVerify stays false",
+			configYAML:          "name: test\n",
+			expectSkipSANVerify: false,
+		},
+		{
+			description:         "empty config: SkipClientSANVerify stays false",
+			configYAML:          "",
+			expectSkipSANVerify: false,
+		},
+	}
+
+	for _, entry := range table {
+		t.Run(entry.description, func(t *testing.T) {
+			g := NewWithT(t)
+			testDir := createTestDir(t)
+			defer deleteTestDir(t, testDir)
+
+			configFilePath := filepath.Join(testDir, "etcd.conf.yaml")
+			err := os.WriteFile(configFilePath, []byte(entry.configYAML), 0600)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			cfg := embed.NewConfig()
+			err = applyPeerSkipClientSANVerify(configFilePath, cfg, logger)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(cfg.PeerTLSInfo.SkipClientSANVerify).To(Equal(entry.expectSkipSANVerify))
+		})
+	}
+}
+
+func TestApplyPeerSkipClientSANVerifyOverwrites(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	table := []struct {
+		description         string
+		preset              bool
+		configYAML          string
+		expectSkipSANVerify bool
+	}{
+		{
+			description:         "preset true, flag false: lowered to false",
+			preset:              true,
+			configYAML:          "name: test\npeer-transport-security:\n  skip-client-san-verification: false\n",
+			expectSkipSANVerify: false,
+		},
+		{
+			description:         "preset true, flag absent: lowered to false",
+			preset:              true,
+			configYAML:          "name: test\n",
+			expectSkipSANVerify: false,
+		},
+		{
+			description:         "preset false, flag true: raised to true",
+			preset:              false,
+			configYAML:          "name: test\npeer-transport-security:\n  skip-client-san-verification: true\n",
+			expectSkipSANVerify: true,
+		},
+	}
+
+	for _, entry := range table {
+		t.Run(entry.description, func(t *testing.T) {
+			g := NewWithT(t)
+			testDir := createTestDir(t)
+			defer deleteTestDir(t, testDir)
+
+			configFilePath := filepath.Join(testDir, "etcd.conf.yaml")
+			err := os.WriteFile(configFilePath, []byte(entry.configYAML), 0600)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			cfg := embed.NewConfig()
+			cfg.PeerTLSInfo.SkipClientSANVerify = entry.preset
+			err = applyPeerSkipClientSANVerify(configFilePath, cfg, logger)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(cfg.PeerTLSInfo.SkipClientSANVerify).To(Equal(entry.expectSkipSANVerify))
+		})
+	}
+}
+
+func TestApplyPeerSkipClientSANVerifyWithMissingFile(t *testing.T) {
+	g := NewWithT(t)
+	logger := zaptest.NewLogger(t)
+	cfg := embed.NewConfig()
+
+	err := applyPeerSkipClientSANVerify("/nonexistent/path/etcd.conf.yaml", cfg, logger)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("failed to read etcd config file"))
+}
+
+func TestApplyPeerSkipClientSANVerifyWithMalformedYAML(t *testing.T) {
+	g := NewWithT(t)
+	logger := zaptest.NewLogger(t)
+	testDir := createTestDir(t)
+	defer deleteTestDir(t, testDir)
+
+	configFilePath := filepath.Join(testDir, "etcd.conf.yaml")
+	// Malformed YAML — unterminated flow sequence after a tab indent.
+	err := os.WriteFile(configFilePath, []byte("peer-transport-security:\n\t\tinvalid: [unterminated"), 0600)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	cfg := embed.NewConfig()
+	err = applyPeerSkipClientSANVerify(configFilePath, cfg, logger)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("failed to unmarshal etcd config for peer-transport-security.skip-client-san-verification"))
 }

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -457,5 +457,5 @@ func TestApplyPeerSkipClientSANVerifyWithMalformedYAML(t *testing.T) {
 	cfg := embed.NewConfig()
 	err = applyPeerSkipClientSANVerify(configFilePath, cfg, logger)
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(err.Error()).To(ContainSubstring("failed to unmarshal etcd config for peer-transport-security.skip-client-san-verification"))
+	g.Expect(err.Error()).To(ContainSubstring("failed to parse etcd config"))
 }


### PR DESCRIPTION

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area security
/kind enhancement


**What this PR does / why we need it**:

This PR Reads `peer-transport-security.skip-client-san-verification` from the etcd config ConfigMap rendered by [etcd-druid](https://github.com/gardener/etcd-druid) and applies it to `embed.Config.PeerTLSInfo.SkipClientSANVerify`.

The key path matches what etcd v3.6 already honors natively — see [`securityConfig`](https://github.com/etcd-io/etcd/blob/main/server/embed/config.go#L485). For etcd v3.4 / v3.5 (which we run today) the value cannot be set via the etcd config file natively (`copySecurityDetails` doesn't propagate it), so we read it ourselves and set it on `embed.Config.PeerTLSInfo` before `embed.StartEtcd` — equivalent to the `--experimental-peer-skip-client-san-verification` CLI flag.

When etcd v3.6 becomes the floor, etcd embed honors this YAML key natively and the wrapper's translation step here drops away in a one-PR delete.

**Which issue(s) this PR fixes**:
Part of  https://github.com/gardener/etcd-druid/issues/1331
Part of https://github.com/gardener/etcd-druid/issues/1237

**Special notes for your reviewer**:

Corresponding etcd-druid PR https://github.com/gardener/etcd-druid/pull/1363

Once this PR  merged, I will open a follow-up PR to cherry-pick / port the change to the release branch to support etcd v3.4 also.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`etcd-wrapper` now supports the `--experimental-peer-skip-client-san-verification` etcd flag by reading `skip-client-san-verification` under `peer-transport-security` in the etcd config file.
```
