### PR TITLE
Upgrade dependencies

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1
       - name: run-test
         run: |
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1
       - name: run-check
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.25.7 AS builder
+FROM golang:1.26.4 AS builder
 WORKDIR /go/src/github.com/gardener/etcd-wrapper
 COPY . .
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/etcd-wrapper
 
-go 1.25.0
+go 1.26.0
 
 // These are test-only dependencies
 require github.com/onsi/gomega v1.37.0
@@ -8,7 +8,7 @@ require github.com/onsi/gomega v1.37.0
 require (
 	go.etcd.io/etcd/client/v3 v3.5.27
 	go.etcd.io/etcd/server/v3 v3.5.27
-	go.uber.org/zap v1.27.1
+	go.uber.org/zap v1.28.0
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -193,12 +193,12 @@ go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9i
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.18.1/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
-go.uber.org/zap v1.27.1 h1:08RqriUEv8+ArZRYSTXy1LeBScaMpVSTBhCeaZYfMYc=
-go.uber.org/zap v1.27.1/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
+go.uber.org/zap v1.28.0 h1:IZzaP1Fv73/T/pBMLk4VutPl36uNC+OSUh3JLG3FIjo=
+go.uber.org/zap v1.28.0/go.mod h1:rDLpOi171uODNm/mxFcuYWxDsqWSAVkFdX4XojSKg/Q=
 go.yaml.in/yaml/v2 v2.4.3 h1:6gvOSjQoTB3vt1l+CU+tSyi/HOjfOjRLJ4YwYZGwRO0=
 go.yaml.in/yaml/v2 v2.4.3/go.mod h1:zSxWcmIDjOzPXpjlTTbAsKokqkDNAVtZO0WOMiT90s8=
-go.yaml.in/yaml/v3 v3.0.3 h1:bXOww4E/J3f66rav3pX3m8w6jDE4knZjGOw8b5Y6iNE=
-go.yaml.in/yaml/v3 v3.0.3/go.mod h1:tBHosrYAkRZjRAOREWbDnBXUf08JOwYq++0QNwQiWzI=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/vendor/go.uber.org/zap/CHANGELOG.md
+++ b/vendor/go.uber.org/zap/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.28.0 (27 Apr 2026)
+Enhancements:
+* [#1534][]: Add `zapcore.CheckPreWriteHook` and `CheckedEntry.Before` method for transforming entries before they are written to any Cores.
+
 ## 1.27.1 (19 Nov 2025) 
 Enhancements:
 * [#1501][]: prevent `Object` from panicking on nils 

--- a/vendor/go.uber.org/zap/zapcore/entry.go
+++ b/vendor/go.uber.org/zap/zapcore/entry.go
@@ -201,6 +201,14 @@ func (a CheckWriteAction) OnWrite(ce *CheckedEntry, _ []Field) {
 
 var _ CheckWriteHook = CheckWriteAction(0)
 
+// CheckPreWriteHook is a function that transforms an Entry and its Fields
+// before they are written to cores. Register one on a CheckedEntry with the
+// Before method.
+//
+// Pre-write hooks run in the order they were added, before any Core's Write
+// method is called. They may modify the Entry and Fields freely.
+type CheckPreWriteHook func(Entry, []Field) (Entry, []Field)
+
 // CheckedEntry is an Entry together with a collection of Cores that have
 // already agreed to log it.
 //
@@ -213,6 +221,7 @@ type CheckedEntry struct {
 	dirty       bool // best-effort detection of pool misuse
 	after       CheckWriteHook
 	cores       []Core
+	before      []CheckPreWriteHook
 }
 
 func (ce *CheckedEntry) reset() {
@@ -225,6 +234,10 @@ func (ce *CheckedEntry) reset() {
 		ce.cores[i] = nil
 	}
 	ce.cores = ce.cores[:0]
+	for i := range ce.before {
+		ce.before[i] = nil
+	}
+	ce.before = ce.before[:0]
 }
 
 // Write writes the entry to the stored Cores, returns any errors, and returns
@@ -253,9 +266,14 @@ func (ce *CheckedEntry) Write(fields ...Field) {
 	}
 	ce.dirty = true
 
+	ent := ce.Entry
+	for i := range ce.before {
+		ent, fields = ce.before[i](ent, fields)
+	}
+
 	var err error
 	for i := range ce.cores {
-		err = multierr.Append(err, ce.cores[i].Write(ce.Entry, fields))
+		err = multierr.Append(err, ce.cores[i].Write(ent, fields))
 	}
 	if err != nil && ce.ErrorOutput != nil {
 		_, _ = fmt.Fprintf(
@@ -293,6 +311,18 @@ func (ce *CheckedEntry) AddCore(ent Entry, core Core) *CheckedEntry {
 // Deprecated: Use [CheckedEntry.After] instead.
 func (ce *CheckedEntry) Should(ent Entry, should CheckWriteAction) *CheckedEntry {
 	return ce.After(ent, should)
+}
+
+// Before adds a pre-write hook that transforms the Entry and Fields before
+// they are written to any registered Cores. Multiple hooks run in the order
+// they were added. It's safe to call this on nil CheckedEntry references.
+func (ce *CheckedEntry) Before(ent Entry, hook CheckPreWriteHook) *CheckedEntry {
+	if ce == nil {
+		ce = getCheckedEntry()
+		ce.Entry = ent
+	}
+	ce.before = append(ce.before, hook)
+	return ce
 }
 
 // After sets this CheckEntry's CheckWriteHook, which will be called after this

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -299,7 +299,7 @@ go.opentelemetry.io/proto/otlp/trace/v1
 # go.uber.org/multierr v1.11.0
 ## explicit; go 1.19
 go.uber.org/multierr
-# go.uber.org/zap v1.27.1
+# go.uber.org/zap v1.28.0
 ## explicit; go 1.19
 go.uber.org/zap
 go.uber.org/zap/buffer


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area open-source
/kind task

**What this PR does / why we need it**:

* Upgrade Go module directive to `1.26.0`.

* Upgrade the builder image to `golang:1.26.4`.

* Upgrade GitHub Actions Go setup from `1.25` to `1.26`.

* Upgrade `go.uber.org/zap` to `v1.28.0`.

* Refresh vendored dependencies, including the corresponding `go.uber.org/zap` vendor changes.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Upgrade Go to `1.26` and `go.uber.org/zap` to `v1.28.0`.
```
`